### PR TITLE
bug: add return [] when categry not exist

### DIFF
--- a/back-end/src/repositories/productRepository.ts
+++ b/back-end/src/repositories/productRepository.ts
@@ -63,6 +63,8 @@ export class ProductRepository implements IProductRepository {
       })
       if (!!categoryEntity) {
         filters.categoryId = { contains: categoryEntity.id }
+      }else{
+        return [];
       }
 
     }


### PR DESCRIPTION
Corrige um erro que acontecia:
Quando era filtrado um produto por categoria e a mesma não existia ele ignorava o filtro e retornava todos os produtos, foi adicionado um return [] caso a exista o filtro por categoria porém a categoria não exista.