### PR TITLE
fix: add id in return dto

### DIFF
--- a/back-end/src/models/listProducts/listProduct.dto.ts
+++ b/back-end/src/models/listProducts/listProduct.dto.ts
@@ -37,7 +37,7 @@ export class ListProductsDto {
         this.name = name;
         this.products = [];
         products.forEach(product => {
-            this.products.push(new ListProductsItemDto("22", product.name, product.price,
+            this.products.push(new ListProductsItemDto(product.id, product.name, product.price,
                 product.category.id, product.category.name, product.imageUrl, product.description, product.idRelation))
         })
     }


### PR DESCRIPTION
Corrige o seguinte error: 
Ao retornar a lista de produtos que estão na lista de favoritos o id do produto vinha como "22" pois estava sendo mocado o numero no código.